### PR TITLE
Refactor: Change Endpoint Examination

### DIFF
--- a/backend/features/examination/schemas/examination_schema.py
+++ b/backend/features/examination/schemas/examination_schema.py
@@ -29,3 +29,7 @@ class ExaminationCreate(BaseModel):
     id_sample: int
     tentative: bool | None = None
     BBox: list[BBoxCreate] | None = None
+
+
+class ExaminationCreateResponse(ExaminationCreate):
+    id: int

--- a/backend/features/packages/services/package_service.py
+++ b/backend/features/packages/services/package_service.py
@@ -2,7 +2,7 @@ import os
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 from repositories.package_repository import PackageRepository
-from models.models import Package
+from models.models import Package, Sample, Examination, Set
 
 
 class PackageService:
@@ -73,3 +73,12 @@ class PackageService:
             if len(package.Sample) < package.Set.package_size:
                 return package.id
         return self.create_package(id_set).id
+
+    def update_package_is_ready(self, sample: Sample, package: Package, set_info: Set):
+        all_samples_have_examination = self.repository.update_package_is_ready(
+            sample, package, set_info
+        )
+        return all_samples_have_examination
+
+    def update_package_is_ready_false(self, sample_id: int):
+        return self.repository.update_package_is_ready_false(sample_id)

--- a/backend/repositories/package_repository.py
+++ b/backend/repositories/package_repository.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
-from models.models import Package, Set, Sample
+from models.models import Package, Set, Sample, Package, Examination
 
 
 class PackageRepository:
@@ -44,3 +44,31 @@ class PackageRepository:
             .filter(Package.Set.has(Set.id_group == id_group))
             .all()
         )
+
+    def update_package_is_ready(self, sample: Sample, package: Package, set_info: Set):
+        all_samples_have_examination = (
+            self.db.query(Sample)
+            .join(Examination, Sample.id == Examination.id_sample)
+            .filter(Sample.id_package == sample.id_package)
+            .count()
+            == set_info.package_size
+        )
+        if all_samples_have_examination:
+            package.is_ready = True
+            self.db.commit()
+            return True
+        else:
+            return False
+
+    def update_package_is_ready_false(self, sample_id: int):
+        sample = self.db.query(Sample).filter(Sample.id == sample_id).first()
+        if sample:
+            package = (
+                self.db.query(Package).filter(Package.id == sample.id_package).first()
+            )
+
+            if package:
+                package.is_ready = False
+                self.db.commit()
+                return True
+        return False


### PR DESCRIPTION
*Add new features: Endpoint PUT /api/examinations check if all samples in package has already examination and if yes, mark package as ready.
*Add new features: Endpoint DELETE /api/examinations always mark package as not ready.
*Add new features: Endpoint PUT /api/examination return examination id in only in response body.
